### PR TITLE
fix (breaking change): gas refill params

### DIFF
--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -60,6 +60,7 @@ func main() {
 	custodial, err := custodial.NewCustodial(custodial.Opts{
 		CeloProvider:     celoProvider,
 		LockProvider:     lockProvider,
+		Logg:             lo,
 		Noncestore:       redisNoncestore,
 		Store:            store,
 		RedisClient:      redisPool.Client,

--- a/internal/custodial/custodial.go
+++ b/internal/custodial/custodial.go
@@ -15,12 +15,14 @@ import (
 	"github.com/grassrootseconomics/w3-celo-patch"
 	"github.com/labstack/gommon/log"
 	"github.com/redis/go-redis/v9"
+	"github.com/zerodha/logf"
 )
 
 type (
 	Opts struct {
 		CeloProvider     *celoutils.Provider
 		LockProvider     *redislock.Client
+		Logg             logf.Logger
 		Noncestore       nonce.Noncestore
 		Store            store.Store
 		RedisClient      *redis.Client
@@ -54,10 +56,12 @@ func NewCustodial(o Opts) (*Custodial, error) {
 		return nil, err
 	}
 
-	_, err = o.Noncestore.Peek(ctx, o.SystemPublicKey)
+	systemNonce, err := o.Noncestore.Peek(ctx, o.SystemPublicKey)
 	if err != nil {
 		return nil, err
 	}
+
+	o.Logg.Info("custodial: loaded_nonce", "system_nonce", systemNonce)
 
 	privateKey, err := eth_crypto.HexToECDSA(o.SystemPrivateKey)
 	if err != nil {

--- a/internal/store/account.go
+++ b/internal/store/account.go
@@ -22,10 +22,10 @@ func (s *PgStore) ActivateAccount(
 func (s *PgStore) GetAccountStatus(
 	ctx context.Context,
 	publicAddress string,
-) (bool, int, error) {
+) (bool, bool, error) {
 	var (
 		accountActive bool
-		gasQuota      int
+		gasLock       bool
 	)
 
 	if err := s.db.QueryRow(
@@ -34,21 +34,21 @@ func (s *PgStore) GetAccountStatus(
 		publicAddress,
 	).Scan(
 		&accountActive,
-		&gasQuota,
+		&gasLock,
 	); err != nil {
-		return false, 0, err
+		return false, false, err
 	}
 
-	return accountActive, gasQuota, nil
+	return accountActive, gasLock, nil
 }
 
-func (s *PgStore) DecrGasQuota(
+func (s *PgStore) GasLock(
 	ctx context.Context,
 	publicAddress string,
 ) error {
 	if _, err := s.db.Exec(
 		ctx,
-		s.queries.DecrGasQuota,
+		s.queries.GasLock,
 		publicAddress,
 	); err != nil {
 		return err
@@ -57,13 +57,13 @@ func (s *PgStore) DecrGasQuota(
 	return nil
 }
 
-func (s *PgStore) ResetGasQuota(
+func (s *PgStore) GasUnlock(
 	ctx context.Context,
 	publicAddress string,
 ) error {
 	if _, err := s.db.Exec(
 		ctx,
-		s.queries.ResetGasQuota,
+		s.queries.GasUnlock,
 		publicAddress,
 	); err != nil {
 		return err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -27,10 +27,10 @@ type (
 		UpdateDispatchStatus(context.Context, bool, string, uint64) error
 		// Account related actions.
 		ActivateAccount(context.Context, string) error
-		GetAccountStatus(context.Context, string) (bool, int, error)
+		GetAccountStatus(context.Context, string) (bool, bool, error)
 		// Gas quota related actions.
-		DecrGasQuota(context.Context, string) error
-		ResetGasQuota(context.Context, string) error
+		GasLock(context.Context, string) error
+		GasUnlock(context.Context, string) error
 	}
 
 	Opts struct {
@@ -57,8 +57,8 @@ type (
 		// Account related queries.
 		ActivateAccount  string `query:"activate-account"`
 		GetAccountStatus string `query:"get-account-status-by-address"`
-		DecrGasQuota     string `query:"decr-gas-quota"`
-		ResetGasQuota    string `query:"reset-gas-quota"`
+		GasLock          string `query:"acc-gas-lock"`
+		GasUnlock        string `query:"acc-gas-unlock"`
 	}
 )
 

--- a/internal/sub/handler.go
+++ b/internal/sub/handler.go
@@ -45,11 +45,11 @@ func (s *Sub) processEventHandler(ctx context.Context, msg *nats.Msg) error {
 				return err
 			}
 
-			if err := s.cu.Store.ResetGasQuota(ctx, chainEvent.To); err != nil {
+			if err := s.cu.Store.GasUnlock(ctx, chainEvent.To); err != nil {
 				return err
 			}
 		case "CHAIN.gas":
-			if err := s.cu.Store.ResetGasQuota(ctx, chainEvent.To); err != nil {
+			if err := s.cu.Store.GasUnlock(ctx, chainEvent.To); err != nil {
 				return err
 			}
 		}

--- a/internal/tasker/task/utils.go
+++ b/internal/tasker/task/utils.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"math/big"
 	"time"
 
 	"github.com/bsm/redislock"
@@ -14,6 +15,15 @@ const (
 	lockTimeout    = 1 * time.Second
 )
 
+var (
+	// 20 gwei = max gas price we are willing to pay
+	// 250k = max gas limit
+	// minGasBalanceRequired is optimistic that the immidiate next transfer request will be successful
+	// but the subsequent one could fail (though low probability), therefore we can trigger a gas lock.
+	// Therefore our system wide threshold is 0.01 CELO or 10000000000000000 gas units
+	minGasBalanceRequired = big.NewInt(20000000000 * 250000 * 2)
+)
+
 // lockRetry will at most try to obtain the lock 20 times within ~0.5s.
 // it is expected to prevent immidiate requeue of the task at the expense of more redis calls.
 func lockRetry() redislock.RetryStrategy {
@@ -21,4 +31,9 @@ func lockRetry() redislock.RetryStrategy {
 		redislock.LinearBackoff(lockRetryDelay),
 		20,
 	)
+}
+
+// balanceCheck compares the network balance with the system set min as threshold to execute a transfer.
+func balanceCheck(networkBalance big.Int) bool {
+	return minGasBalanceRequired.Cmp(&networkBalance) < 0
 }

--- a/migrations/005_remove_gas_quota.sql
+++ b/migrations/005_remove_gas_quota.sql
@@ -1,0 +1,34 @@
+-- Replace gas_quota with gas_lock which checks network balance threshold 
+DROP TRIGGER IF EXISTS update_gas_quota_timestamp ON gas_quota;
+DROP TABLE IF EXISTS gas_quota_meta;
+DROP TABLE IF EXISTS gas_quota;
+DROP TRIGGER IF EXISTS insert_gas_quota ON keystore;
+DROP FUNCTION IF EXISTS insert_gas_quota;
+
+-- Gas lock table
+-- A gas_locked account indicates gas balance is below threshold awaiting next available top up
+CREATE TABLE IF NOT EXISTS gas_lock (
+    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    key_id INT REFERENCES keystore(id) NOT NULL,
+    lock BOOLEAN DEFAULT true,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+create function insert_gas_lock()
+    returns trigger
+as $$
+begin
+    insert into gas_lock (key_id) values (new.id);
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger insert_gas_lock
+    after insert on keystore
+for each row
+execute procedure insert_gas_lock();
+
+create trigger update_gas_lock_timestamp
+    before update on gas_lock
+for each row
+execute procedure update_timestamp();

--- a/queries.sql
+++ b/queries.sql
@@ -73,27 +73,24 @@ UPDATE otx_dispatch SET "status" = $2, "block" = $3 WHERE otx_dispatch.id = (
 UPDATE keystore SET active = true WHERE public_key=$1
 
 --name: get-account-status-by-address
--- Gets current gas quota for an individual account by address
+-- Gets current gas lock and activation status for an individual account by address
 -- $1: public_key
-SELECT keystore.active, gas_quota.quota FROM keystore
-INNER JOIN gas_quota ON keystore.id = gas_quota.key_id
+SELECT keystore.active, gas_lock.lock FROM keystore
+INNER JOIN gas_lock ON keystore.id = gas_lock.key_id
 WHERE keystore.public_key=$1
 
---name: decr-gas-quota
--- Consumes a gas quota
+--name: acc-gas-lock
+-- Locks an account for gas reasons
 -- $1: public_key
-UPDATE gas_quota SET quota = quota - 1 WHERE key_id = (
+UPDATE gas_lock SET lock = true WHERE key_id = (
     SELECT id FROM keystore
     WHERE public_key=$1    
 )
 
---name: reset-gas-quota
--- Resets the gas quota
--- 25 is the agreed upon quota
+--name: acc-gas-unlock
+-- Unlocks an account for gas reasons
 -- $1: public_key
-UPDATE gas_quota SET quota = gas_quota_meta.default_quota
-FROM gas_quota_meta
-WHERE key_id = (
+UPDATE gas_lock SET lock = false WHERE key_id = (
     SELECT id FROM keystore
     WHERE public_key=$1    
 )


### PR DESCRIPTION
NOTE: This needs the db to be nuked if you are running a test cluster

* updated gas refilling logic to reflect EthFaucet contract
* fully dependant on on-chain contract to refill and unlock gas
* minor fixes to nonce bootstrapper

Ideal Values:

INITIAL GIFT = 0.015
THRESHOLD    = 0.01
TIME = 12 * 60 * 60

# Sample for 30 txs
EXTREME LOW = 0.00675
LOW GAS USAGE = 0.00694605
RISING = 0.0135
HIGH = 0.027